### PR TITLE
Adds another gatemaster slot

### DIFF
--- a/code/modules/jobs/job_types/roguetown/garrison/gatemaster.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/gatemaster.dm
@@ -3,8 +3,8 @@
 	flag = GATEMASTER
 	department_flag = GARRISON
 	faction = "Station"
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 2
+	spawn_positions = 2
 	allowed_sexes = list(MALE)
 	allowed_races = RACES_TOLERATED_UP
 	allowed_patrons = ALL_DIVINE_PATRONS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
So, gatemaster... the role where you sit at a desk for three hours and then listen to retards telling you "open". You wouldnt even be able to pay me to do that IRL. So to slopfix this, I am adding a second gatemaster slot to keep em company so they can take turns resting and manning the gate or having these things called "break times."
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
gatemasters cant catch a break and no MAA wants to man the gate at all. This PR was poorly thought out and has not been tested so issues may arise. This should make gatekeeper a bit less of a shit job since there are two of them to share the burden. Yes I am aware that this is not a perfect fix, yes I believe that this is probably a good thing.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
