### PR TITLE
Renamed skills again

### DIFF
--- a/code/controllers/subsystem/skills.dm
+++ b/code/controllers/subsystem/skills.dm
@@ -10,14 +10,13 @@ SUBSYSTEM_DEF(skills)
 	var/list/all_skills = list()
 	///Static assoc list of levels (ints) - strings
 	var/static/list/level_names = list( // Why did I change the level names you ask? It's very shrimple. Because they flow better in a sentence. Like-- "Journeymanly"??? "Apprenticely"???
-		SKILL_LEVEL_NOVICE = span_info("<span class='small'>Novice</span>"), 
-		SKILL_LEVEL_APPRENTICE = span_info("Amateur"), 
-		SKILL_LEVEL_JOURNEYMAN = span_biginfo("Competent"), 
-		SKILL_LEVEL_EXPERT = span_biginfo("<span style='color: green;'>Adept</span>"), 
+		SKILL_LEVEL_NOVICE = span_info("<span class='small'>Beginner</span>"), 
+		SKILL_LEVEL_APPRENTICE = span_info("Competent"), 
+		SKILL_LEVEL_JOURNEYMAN = span_biginfo("Professional"), 
+		SKILL_LEVEL_EXPERT = span_biginfo("<span style='color: green;'>Elite</span>"), 
 		SKILL_LEVEL_MASTER = "<b>Expert</b>", 
 		SKILL_LEVEL_LEGENDARY = "<b><span style='color: gold;'>Master</span></b>",
 	)//This list is already in the right order, due to indexing
-
 /datum/controller/subsystem/skills/Initialize(timeofday)
 	InitializeSkills()
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Renamed skills so they are better defined what the different classes are
![{9F90E8B4-223E-40C2-83CF-41DFC536A2C8}](https://github.com/user-attachments/assets/4c016085-2a52-4b6c-8e19-2fd7642619e7)
the person who wrote these names are not opposed to it
https://github.com/Rotwood-Vale/Ratwood-Keep/pull/2310/files
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The current skill names are a bit confusing and could better fit with the existing game skill level balance ideas
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->


## Proof of Testing (Required)
It's impossible to break anything with this
<!-- Show proof of testing, screenshots or recordings for features, proof of compile for backend changes -->
